### PR TITLE
fix standardization import examples

### DIFF
--- a/new_pages/data_used.qmd
+++ b/new_pages/data_used.qmd
@@ -232,13 +232,15 @@ See the page on [Standardised rates](standardization.qmd). You can load the data
 
 ```{r, eval=F}
 # install/load the rio package
-pacman::p_load(rio) 
+pacman::p_load(rio, tidyverse)
 
 ##############
 # Country A
 ##############
 # import demographics for country A directly from Github
-A_demo <- import("https://github.com/appliedepi/epirhandbook_eng/raw/master/data/standardization/country_demographics.csv")
+A_demo <- import("https://github.com/appliedepi/epirhandbook_eng/raw/master/data/standardization/country_demographics.csv") %>%
+     mutate(Country = "A") %>%
+     select(Country, everything())
 
 # import deaths for country A directly from Github
 A_deaths <- import("https://github.com/appliedepi/epirhandbook_eng/raw/master/data/standardization/deaths_countryA.csv")
@@ -247,7 +249,9 @@ A_deaths <- import("https://github.com/appliedepi/epirhandbook_eng/raw/master/da
 # Country B
 ##############
 # import demographics for country B directly from Github
-B_demo <- import("https://github.com/appliedepi/epirhandbook_eng/raw/master/data/standardization/country_demographics_2.csv")
+B_demo <- import("https://github.com/appliedepi/epirhandbook_eng/raw/master/data/standardization/country_demographics_2.csv", format = ";") %>%
+     mutate(Country = "B") %>%
+     select(Country, everything())
 
 # import deaths for country B directly from Github
 B_deaths <- import("https://github.com/appliedepi/epirhandbook_eng/raw/master/data/standardization/deaths_countryB.csv")

--- a/new_pages/standardization.qmd
+++ b/new_pages/standardization.qmd
@@ -79,13 +79,17 @@ See the [Download handbook and data](data_used.qmd) page for instructions on how
 
 ```{r, eval=F}
 # import demographics for country A directly from Github
-A_demo <- import("https://github.com/appliedepi/epirhandbook_eng/raw/master/data/standardization/country_demographics.csv")
+A_demo <- import("https://github.com/appliedepi/epirhandbook_eng/raw/master/data/standardization/country_demographics.csv") %>%
+     mutate(Country = "A") %>%
+     select(Country, everything())
 
 # import deaths for country A directly from Github
 A_deaths <- import("https://github.com/appliedepi/epirhandbook_eng/raw/master/data/standardization/deaths_countryA.csv")
 
 # import demographics for country B directly from Github
-B_demo <- import("https://github.com/appliedepi/epirhandbook_eng/raw/master/data/standardization/country_demographics_2.csv")
+B_demo <- import("https://github.com/appliedepi/epirhandbook_eng/raw/master/data/standardization/country_demographics_2.csv", format = ";") %>%
+     mutate(Country = "B") %>%
+     select(Country, everything())
 
 # import deaths for country B directly from Github
 B_deaths <- import("https://github.com/appliedepi/epirhandbook_eng/raw/master/data/standardization/deaths_countryB.csv")


### PR DESCRIPTION
Fixes #425.

The Chapter 21 GitHub import example now matches the working code later in the chapter: it adds `Country` to `A_demo` and `B_demo` before the downstream join. The B demographic import also sets `format = ";"` because that file is semicolon-delimited.

The same fix is applied to the data download snippet.

Testing: `git diff --check`; local R schema check for the standardization import columns.

Not run: Quarto render, `quarto` is not installed locally.