### PR TITLE
Fix broken links in index.qmd 

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -34,7 +34,7 @@ knitr::include_graphics(here::here("images", "Epi R Handbook banner beige 1500x5
 
 **Objective:** Serve as a quick R code reference manual (online and [**offline**](#data-used)) with task-centered examples that address common epidemiological problems.
 
-**Are you just starting with R?** Try our [**free interactive tutorials**](https://www.appliedepi.org/tutorial/) or synchronous, virtual [**intro course**](https://www.appliedepi.org/live/) used by US CDC, WHO, and 400+ other health agencies and Field Epi Training Programs worldwide.
+**Are you just starting with R?** Try our [**free interactive tutorials**](https://www.appliedepi.org/resources/tutorials.html) or synchronous, virtual [**intro course**](https://appliedepi.org/training/training.html) used by US CDC, WHO, and 400+ other health agencies and Field Epi Training Programs worldwide.
 
 **Languages:** [French (Français)](https://epirhandbook.com/fr), [Spanish (Español)](https://epirhandbook.com/es/), [Vietnamese (Tiếng Việt)](https://epirhandbook.com/vn/), [Japanese (日本)](https://epirhandbook.com/jp/), [Turkish (Türkçe)](https://epirhandbook.com/tr/), [Portuguese (Português)](https://epirhandbook.com/pt), [Russian (Русский)](https://epirhandbook.com/ru)
 
@@ -76,7 +76,7 @@ a column separator -->
 -   **contact\@appliedepi.org**, tweet [**\@appliedepi**](https://twitter.com/appliedepi), or [**LinkedIn**](www.linkedin.com/company/appliedepi)\
 -   Submit issues to our [**Github repository**](https://github.com/appliedepi/epiRhandbook_eng)
 
-**We offer live R training** from instructors with decades of applied epidemiology experience - [www.appliedepi.org/live](www.appliedepi.org/live).
+**We offer live R training** from instructors with decades of applied epidemiology experience - [www.appliedepi.org/live](https://appliedepi.org/training/training.html).
 
 </div>
 :::


### PR DESCRIPTION
Some of the links are broken. The pull request changes the links to what I think is the correct destination. For example:

Before
<img width="1214" height="638" alt="image" src="https://github.com/user-attachments/assets/8098fde9-4409-4a20-9cfc-f01574351276" />

After
<img width="1214" height="638" alt="image" src="https://github.com/user-attachments/assets/fb58e6ec-8c3b-406a-b5fc-23b441effa15" />
