### PR TITLE
Fix broken links in Spanish version of index

### DIFF
--- a/index.es.qmd
+++ b/index.es.qmd
@@ -33,7 +33,7 @@ knitr::include_graphics(here::here("images", "Epi R Handbook Banner Spanish en e
 
 **Objetivo:** Servir como breve guía de referencia para escribir código en R (en línea y [**versión sin conexión**](#download-handbook-and-data)) con ejemplos detallados que aborden problemas epidemiológicos.  
 
-**¿Estás empezando con R?** Prueba nuestros **[tutoriales interactivos gratuitos](https://www.appliedepi.org/tutorial/)** o **[el curso de introducción](https://appliedepi.org/training/training.html)** sincrónico, utilizado por los CDC de EE.UU., la OMS, y más de 400 agencias de salud y programas de formación de Epi de campo.  
+**¿Estás empezando con R?** Prueba nuestros **[tutoriales interactivos gratuitos](https://appliedepi.org/resources/tutorials.html)** o **[el curso de introducción](https://appliedepi.org/training/training.html)** sincrónico, utilizado por los CDC de EE.UU., la OMS, y más de 400 agencias de salud y programas de formación de Epi de campo.  
 
 **Idiomas:** [Inglés (English)](https://www.epirhandbook.com/en), [Francés (Français)](https://epirhandbook.com/fr), [Español](https://epirhandbook.com/es/), [Vietnamita (Tiếng Việt)](https://epirhandbook.com/vn/), [Japonés (日本)](https://epirhandbook.com/jp/), [Turco (Türkçe)](https://epirhandbook.com/tr/), [Portugués (Português)](https://epirhandbook.com/pt),  [Ruso (Русский)](https://epirhandbook.com/ru)  
 

--- a/index.es.qmd
+++ b/index.es.qmd
@@ -33,7 +33,7 @@ knitr::include_graphics(here::here("images", "Epi R Handbook Banner Spanish en e
 
 **Objetivo:** Servir como breve guía de referencia para escribir código en R (en línea y [**versión sin conexión**](#download-handbook-and-data)) con ejemplos detallados que aborden problemas epidemiológicos.  
 
-**¿Estás empezando con R?** Prueba nuestros **[tutoriales interactivos gratuitos](https://www.appliedepi.org/tutorial/)** o **[el curso de introducción](https://www.appliedepi.org/live/)** sincrónico, utilizado por los CDC de EE.UU., la OMS, y más de 400 agencias de salud y programas de formación de Epi de campo.  
+**¿Estás empezando con R?** Prueba nuestros **[tutoriales interactivos gratuitos](https://www.appliedepi.org/tutorial/)** o **[el curso de introducción](https://appliedepi.org/training/training.html)** sincrónico, utilizado por los CDC de EE.UU., la OMS, y más de 400 agencias de salud y programas de formación de Epi de campo.  
 
 **Idiomas:** [Inglés (English)](https://www.epirhandbook.com/en), [Francés (Français)](https://epirhandbook.com/fr), [Español](https://epirhandbook.com/es/), [Vietnamita (Tiếng Việt)](https://epirhandbook.com/vn/), [Japonés (日本)](https://epirhandbook.com/jp/), [Turco (Türkçe)](https://epirhandbook.com/tr/), [Portugués (Português)](https://epirhandbook.com/pt),  [Ruso (Русский)](https://epirhandbook.com/ru)  
 
@@ -76,7 +76,7 @@ a column separator -->
 * Email **contact@appliedepi.org**, tweet **[\@epiRhandbook](https://twitter.com/epirhandbook)**  o  [Linkedin](https://www.linkedin.com/company/appliedepi)
 * Envía problemas a nuestro **[repositorio Github](https://github.com/appliedepi/epiRhandbook_eng)**  
 
-**Ofrecemos formación en R** impartida por instructores con décadas de experiencia en epidemiología aplicada - [www.appliedepi.org/live](www.appliedepi.org/live).
+**Ofrecemos formación en R** impartida por instructores con décadas de experiencia en epidemiología aplicada - [www.appliedepi.org/live](https://appliedepi.org/training/training.html).
 
 
 :::
@@ -95,7 +95,7 @@ a column separator -->
 
 * Navega por las páginas del índice o utiliza el cuadro de búsqueda
 * Clica en los iconos "Copy" para copiar el código  
-* Puedes seguir paso a paso las lecciones utilizando nuestros [datos de ejemplo][Download handbook and data]  
+* Puedes seguir paso a paso las lecciones utilizando nuestros [datos de ejemplo](#download-handbook-and-data)  
 
 **Versión sin conexión**  
 


### PR DESCRIPTION
This pull request fixes 3 types of broken links:
1. Links to the tutorials
2. Links to the live training page
3. One incorrectly formatted Markdown link to the example data