### PR TITLE
Fix markdown table in spanish version

### DIFF
--- a/new_pages/editorial_style.es.qmd
+++ b/new_pages/editorial_style.es.qmd
@@ -111,7 +111,7 @@ Limpiar los nombres de las columnas|**linelist**, **janitor**|**janitor**|Se hac
 Semanas epidemiológicas. Epiweeks |**lubridate**, **aweek**, **tsibble**, **zoo**|Normalmente **lubridate**, los otros para casos específicos|La flexibilidad, la coherencia y las perspectivas de mantenimiento de los paquetes de **lubridate**
 Etiquetas ggplot|`labs()`, `ggtitle()`/`ylab()`/`xlab()` |`labs()` |Todas las etiquetas en un solo lugar, la simplicidad  
 Convertir en factor |`factor()`, **forcats**|**forcats**|Sus diversas funciones también se convierten en factor en el mismo comando
-Curvas epidémicas|**incidence**, **ggplot2**, **EpiCurve**|**incidence2** por rapidez`, **ggplot2** para tareas detalladas|fiabilidad
+Curvas epidémicas|**incidence**, **ggplot2**, **EpiCurve**|**incidence2** por rapidez`, **ggplot2** para tareas detalladas|fiabilidad    
 Concatenación|`paste()`, `paste0()`, `str_glue()`, `glue()`|`str_glue()`|Sintaxis más sencilla que las funciones de pegado; dentro de **stringr**
 
 


### PR DESCRIPTION
It looks like there weren't enough spaces between the second to last and last row so the last row became a cell instead of a new row. This pull request adds the spaces.

<img width="972" height="301" alt="image" src="https://github.com/user-attachments/assets/7e99ea78-010d-4a13-8859-cc21b8e1df55" />
